### PR TITLE
Fix extension of merged file

### DIFF
--- a/src/Helper/ChunkHelpers.php
+++ b/src/Helper/ChunkHelpers.php
@@ -145,9 +145,9 @@ trait ChunkHelpers
      */
     private function correctMergedExt(Filesystem $disk, string $mergedDirectory, string $targetFilename): string
     {
+        $targetPath = $mergedDirectory . '/' . $targetFilename;
         $ext = pathinfo($targetFilename, PATHINFO_EXTENSION);
         if ($ext === 'bin') {
-            $targetPath = $mergedDirectory . '/' . $targetFilename;
             $var = $disk->path($targetPath);
             $uploadedFile = new UploadedFile($var, $targetFilename);
             $filename = pathinfo($targetFilename, PATHINFO_FILENAME);


### PR DESCRIPTION
This PR fixes the guessed extension of binary files.

In case of a binary file (eg. mp4) the guessed extension of a chunk is `bin`. We can fix this by guessing the extension of the merged file.