### PR TITLE
Fix Resumable.js response code on test request

### DIFF
--- a/src/Driver/ResumableJsUploadDriver.php
+++ b/src/Driver/ResumableJsUploadDriver.php
@@ -14,7 +14,6 @@ use LaraCrafts\ChunkUploader\StorageConfig;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResumableJsUploadDriver extends UploadDriver
 {
@@ -106,7 +105,7 @@ class ResumableJsUploadDriver extends UploadDriver
         $chunkname = $this->buildChunkname($range);
 
         if (! $this->chunkExists($config, $filename, $chunkname)) {
-            throw new NotFoundHttpException();
+            return new Response('', Response::HTTP_NO_CONTENT);
         }
 
         return new JsonResponse(['OK']);

--- a/tests/Driver/ResumableJsUploadDriverTest.php
+++ b/tests/Driver/ResumableJsUploadDriverTest.php
@@ -13,9 +13,9 @@ use LaraCrafts\ChunkUploader\Exception\InternalServerErrorHttpException;
 use LaraCrafts\ChunkUploader\Tests\TestCase;
 use LaraCrafts\ChunkUploader\UploadHandler;
 use Mockery;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResumableJsUploadDriverTest extends TestCase
 {
@@ -85,9 +85,8 @@ class ResumableJsUploadDriverTest extends TestCase
             'resumableType' => 'text/plain',
         ]);
 
-        $this->expectException(NotFoundHttpException::class);
-
-        $this->createTestResponse($this->handler->handle($request));
+        $response = $this->createTestResponse($this->handler->handle($request));
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
     }
 
     public function testResume()


### PR DESCRIPTION
test request documentation of Resumable.js: https://github.com/23/resumable.js#handling-get-or-test-requests

> If the request returns anything else, the chunk will be uploaded in the standard fashion. (It is recommended to return 204 No Content in these cases if possible to avoid unwarranted notices in browser consoles.)

Before the library throw a `NotFoundHttpException` when the chunk of the file was missing. Now it is returning a `204 No Content` response as suggested by the documentation.