### PR TITLE
Add Flow.js driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ project at the moment is [tus](https://tus.io/).
     - [Monolith](#monolith-driver)
     - [Blueimp](#blueimp-driver)
     - [DropzoneJS](#dropzonejs-driver)
+    - [Flow.js](#flow-js-driver)
     - [Resumable.js](#resumable-js-driver)
 - [Identifiers](#identifiers)
     - [Session identifier](#session-identifier)
@@ -148,6 +149,7 @@ Service                              | Driver name    | Chunk upload | Resumable
 [Monolith](#monolith-driver)         | `monolith`     | no           | no
 [Blueimp](#blueimp-driver)           | `blueimp`      | yes          | yes
 [DropzoneJS](#dropzonejs-driver)     | `dropzone`     | yes          | no
+[Flow.js](#flow-js-driver)           | `flow-js`      | yes          | yes
 [Resumable.js](#resumable-js-driver) | `resumable-js` | yes          | yes
 
 ### Monolith driver
@@ -165,6 +167,12 @@ This driver handles requests made by the Blueimp jQuery File Upload client libra
 [website](https://www.dropzonejs.com/)
 
 This driver handles requests made by the DropzoneJS client library.
+
+### Flow.js driver
+
+[website](https://github.com/flowjs/flow.js)
+
+This driver handles requests made by the Flow.js client library.
 
 ### Resumable.js driver
 

--- a/config/chunk-uploader.php
+++ b/config/chunk-uploader.php
@@ -120,6 +120,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Flow.js Options
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the options for the Flow.js driver.
+    |
+    */
+
+    'flow-js' => [
+
+        // The name of the multipart request parameter to use for the file chunk
+        'param' => 'file',
+
+        //  HTTP method for chunk test request.
+        'test-method' => Illuminate\Http\Request::METHOD_GET,
+        //  HTTP method to use when sending chunks to the server (POST, PUT, PATCH).
+        'upload-method' => Illuminate\Http\Request::METHOD_POST,
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Resumable.js Options
     |--------------------------------------------------------------------------
     |

--- a/config/chunk-uploader.php
+++ b/config/chunk-uploader.php
@@ -12,7 +12,7 @@ return [
     | throughout your application here. By default, the module is setup for
     | monolith upload.
     |
-    | Supported: "monolith", "blueimp", "dropzone", "resumable-js"
+    | Supported: "monolith", "blueimp", "dropzone", "flow-js", "resumable-js"
     |
     */
 

--- a/src/Driver/FlowJsUploadDriver.php
+++ b/src/Driver/FlowJsUploadDriver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace LaraCrafts\ChunkUploader\Driver;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use InvalidArgumentException;
+use LaraCrafts\ChunkUploader\Helper\ChunkHelpers;
+use LaraCrafts\ChunkUploader\Range\OneBasedRequestBodyRange;
+use LaraCrafts\ChunkUploader\Response\PercentageJsonResponse;
+use LaraCrafts\ChunkUploader\StorageConfig;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class FlowJsUploadDriver extends ResumableJsUploadDriver
+{
+    /**
+     * ResumableJsUploadDriver constructor.
+     *
+     * @param array $config
+     */
+    public function __construct($config)
+    {
+        $config['parameter-namespace'] = '';
+        $config['parameter-names'] = [
+            // The name of the chunk index (base-1) in the current upload POST parameter to use for the file chunk.
+            'chunk-number' => 'flowChunkNumber',
+            // The name of the total number of chunks POST parameter to use for the file chunk.
+            'total-chunks' => 'flowTotalChunks',
+            // The name of the general chunk size POST parameter to use for the file chunk.
+            'chunk-size' => 'flowChunkSize',
+            // The name of the total file size number POST parameter to use for the file chunk.
+            'total-size' => 'flowTotalSize',
+            // The name of the unique identifier POST parameter to use for the file chunk.
+            'identifier' => 'flowIdentifier',
+            // The name of the original file name POST parameter to use for the file chunk.
+            'file-name' => 'flowFilename',
+            // The name of the file's relative path POST parameter to use for the file chunk.
+            'relative-path' => 'flowRelativePath',
+            // The name of the current chunk size POST parameter to use for the file chunk.
+            'current-chunk-size' => 'flowCurrentChunkSize',
+        ];
+        parent::__construct($config);
+    }
+}

--- a/src/Driver/FlowJsUploadDriver.php
+++ b/src/Driver/FlowJsUploadDriver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaraCrafts\ChunkUploader\Driver;
+namespace CodingSocks\ChunkUploader\Driver;
 
 class FlowJsUploadDriver extends ResumableJsUploadDriver
 {

--- a/src/Driver/FlowJsUploadDriver.php
+++ b/src/Driver/FlowJsUploadDriver.php
@@ -2,20 +2,6 @@
 
 namespace LaraCrafts\ChunkUploader\Driver;
 
-use Closure;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
-use Illuminate\Http\UploadedFile;
-use InvalidArgumentException;
-use LaraCrafts\ChunkUploader\Helper\ChunkHelpers;
-use LaraCrafts\ChunkUploader\Range\OneBasedRequestBodyRange;
-use LaraCrafts\ChunkUploader\Response\PercentageJsonResponse;
-use LaraCrafts\ChunkUploader\StorageConfig;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-
 class FlowJsUploadDriver extends ResumableJsUploadDriver
 {
     /**

--- a/src/UploadManager.php
+++ b/src/UploadManager.php
@@ -5,6 +5,7 @@ namespace LaraCrafts\ChunkUploader;
 use Illuminate\Support\Manager;
 use LaraCrafts\ChunkUploader\Driver\BlueimpUploadDriver;
 use LaraCrafts\ChunkUploader\Driver\DropzoneUploadDriver;
+use LaraCrafts\ChunkUploader\Driver\FlowJsUploadDriver;
 use LaraCrafts\ChunkUploader\Driver\MonolithUploadDriver;
 use LaraCrafts\ChunkUploader\Driver\ResumableJsUploadDriver;
 
@@ -26,6 +27,11 @@ class UploadManager extends Manager
     public function createDropzoneDriver()
     {
         return new DropzoneUploadDriver($this->app['config']['chunk-uploader.dropzone']);
+    }
+
+    public function createFlowJsDriver()
+    {
+        return new FlowJsUploadDriver($this->app['config']['chunk-uploader.resumable-js']);
     }
 
     public function createResumableJsDriver()

--- a/tests/Driver/FlowJsUploadDriverTest.php
+++ b/tests/Driver/FlowJsUploadDriverTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace LaraCrafts\ChunkUploader\Tests\Driver;
+namespace CodingSocks\ChunkUploader\Tests\Driver;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
-use LaraCrafts\ChunkUploader\Driver\FlowJsUploadDriver;
-use LaraCrafts\ChunkUploader\Event\FileUploaded;
-use LaraCrafts\ChunkUploader\Exception\InternalServerErrorHttpException;
-use LaraCrafts\ChunkUploader\Tests\TestCase;
-use LaraCrafts\ChunkUploader\UploadHandler;
+use CodingSocks\ChunkUploader\Driver\FlowJsUploadDriver;
+use CodingSocks\ChunkUploader\Event\FileUploaded;
+use CodingSocks\ChunkUploader\Exception\InternalServerErrorHttpException;
+use CodingSocks\ChunkUploader\Tests\TestCase;
+use CodingSocks\ChunkUploader\UploadHandler;
 use Mockery;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/tests/Driver/FlowJsUploadDriverTest.php
+++ b/tests/Driver/FlowJsUploadDriverTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace LaraCrafts\ChunkUploader\Tests\Driver;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
+use LaraCrafts\ChunkUploader\Driver\FlowJsUploadDriver;
+use LaraCrafts\ChunkUploader\Event\FileUploaded;
+use LaraCrafts\ChunkUploader\Exception\InternalServerErrorHttpException;
+use LaraCrafts\ChunkUploader\Tests\TestCase;
+use LaraCrafts\ChunkUploader\UploadHandler;
+use Mockery;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
+class FlowJsUploadDriverTest extends TestCase
+{
+    /**
+     * @var UploadHandler
+     */
+    private $handler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make('config')->set('chunk-uploader.uploader', 'flow-js');
+        $this->app->make('config')->set('chunk-uploader.sweep', false);
+        $this->handler = $this->app->make(UploadHandler::class);
+
+        Storage::fake('local');
+        Event::fake();
+    }
+
+    public function testDriverInstance()
+    {
+        $manager = $this->app->make('chunk-uploader.upload-manager');
+
+        $this->assertInstanceOf(FlowJsUploadDriver::class, $manager->driver());
+    }
+
+    public function notAllowedRequestMethods()
+    {
+        return [
+            'HEAD' => [Request::METHOD_HEAD],
+            'PUT' => [Request::METHOD_PUT],
+            'PATCH' => [Request::METHOD_PATCH],
+            'DELETE' => [Request::METHOD_DELETE],
+            'PURGE' => [Request::METHOD_PURGE],
+            'OPTIONS' => [Request::METHOD_OPTIONS],
+            'TRACE' => [Request::METHOD_TRACE],
+            'CONNECT' => [Request::METHOD_CONNECT],
+        ];
+    }
+
+    /**
+     * @dataProvider notAllowedRequestMethods
+     */
+    public function testMethodNotAllowed($requestMethod)
+    {
+        $request = Request::create('', $requestMethod);
+
+        $this->expectException(MethodNotAllowedHttpException::class);
+
+        $this->createTestResponse($this->handler->handle($request));
+    }
+
+    public function testResumeWhenChunkDoesNotExists()
+    {
+        $this->createFakeLocalFile('chunks/200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt', '000-099');
+
+        $request = Request::create('', Request::METHOD_GET, [
+            'flowChunkNumber' => 2,
+            'flowTotalChunks' => 2,
+            'flowChunkSize' => 100,
+            'flowTotalSize' => 200,
+            'flowIdentifier' => '200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt',
+            'flowFilename' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowRelativePath' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowCurrentChunkSize' => 100,
+        ]);
+
+        $response = $this->createTestResponse($this->handler->handle($request));
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
+    }
+
+    public function testResume()
+    {
+        $this->createFakeLocalFile('chunks/200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt', '000-099');
+
+        $request = Request::create('', Request::METHOD_GET, [
+            'flowChunkNumber' => 1,
+            'flowTotalChunks' => 2,
+            'flowChunkSize' => 100,
+            'flowTotalSize' => 200,
+            'flowIdentifier' => '200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt',
+            'flowFilename' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowRelativePath' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowCurrentChunkSize' => 100,
+        ]);
+
+        $response = $this->createTestResponse($this->handler->handle($request));
+        $response->assertSuccessful();
+    }
+
+    public function testUploadWhenFileParameterIsEmpty()
+    {
+        $request = Request::create('', Request::METHOD_POST);
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->handler->handle($request);
+    }
+
+    public function testUploadWhenFileParameterIsInvalid()
+    {
+        $file = Mockery::mock(UploadedFile::class)
+            ->makePartial();
+        $file->shouldReceive('isValid')
+            ->andReturn(false);
+
+        $request = Request::create('', Request::METHOD_POST, [], [], [
+            'file' => $file,
+        ]);
+
+        $this->expectException(InternalServerErrorHttpException::class);
+
+        $this->handler->handle($request);
+    }
+
+    public function excludedPostParameterProvider()
+    {
+        return [
+            'flowChunkNumber' => ['flowChunkNumber'],
+            'flowTotalChunks' => ['flowTotalChunks'],
+            'flowChunkSize' => ['flowChunkSize'],
+            'flowTotalSize' => ['flowTotalSize'],
+            'flowIdentifier' => ['flowIdentifier'],
+            'flowFilename' => ['flowFilename'],
+            'flowRelativePath' => ['flowRelativePath'],
+            'flowCurrentChunkSize' => ['flowCurrentChunkSize'],
+        ];
+    }
+
+    /**
+     * @dataProvider excludedPostParameterProvider
+     */
+    public function testPostParameterValidation($exclude)
+    {
+        $arr = [
+            'flowChunkNumber' => 1,
+            'flowTotalChunks' => 2,
+            'flowChunkSize' => 100,
+            'flowTotalSize' => 200,
+            'flowIdentifier' => '200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt',
+            'flowFilename' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowRelativePath' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowCurrentChunkSize' => 100,
+        ];
+
+        unset($arr[$exclude]);
+
+        $request = Request::create('', Request::METHOD_POST, $arr, [], [
+            'file' => UploadedFile::fake()
+                ->create('test.txt', 100),
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $this->handler->handle($request);
+    }
+
+    public function testUploadFirstChunk()
+    {
+        $file = UploadedFile::fake()->create('test.txt', 100);
+        $request = Request::create('', Request::METHOD_POST, [
+            'flowChunkNumber' => 1,
+            'flowTotalChunks' => 2,
+            'flowChunkSize' => 100,
+            'flowTotalSize' => 200,
+            'flowIdentifier' => '200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt',
+            'flowFilename' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowRelativePath' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowCurrentChunkSize' => 100,
+        ], [], [
+            'file' => $file,
+        ]);
+
+        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
+        $response = $this->createTestResponse($this->handler->handle($request));
+        $response->assertSuccessful();
+        $response->assertJson(['done' => 50]);
+
+        Storage::disk('local')->assertExists('chunks/200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt/000-099');
+
+        Event::assertNotDispatched(FileUploaded::class, function ($event) use ($file) {
+            return $event->file = $file->hashName('merged');
+        });
+    }
+
+    public function testUploadFirstChunkWithCallback()
+    {
+        $file = UploadedFile::fake()->create('test.txt', 100);
+        $request = Request::create('', Request::METHOD_POST, [
+            'flowChunkNumber' => 1,
+            'flowTotalChunks' => 2,
+            'flowChunkSize' => 100,
+            'flowTotalSize' => 200,
+            'flowIdentifier' => '200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt',
+            'flowFilename' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowRelativePath' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowCurrentChunkSize' => 100,
+        ], [], [
+            'file' => $file,
+        ]);
+
+        $callback = $this->createClosureMock($this->never());
+
+        $this->handler->handle($request, $callback);
+
+        Event::assertNotDispatched(FileUploaded::class, function ($event) use ($file) {
+            return $event->file = $file->hashName('merged');
+        });
+    }
+
+    public function testUploadLastChunk()
+    {
+        $this->createFakeLocalFile('chunks/200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt', '000-099');
+
+        $file = UploadedFile::fake()->create('test.txt', 100);
+        $request = Request::create('', Request::METHOD_POST, [
+            'flowChunkNumber' => 2,
+            'flowTotalChunks' => 2,
+            'flowChunkSize' => 100,
+            'flowTotalSize' => 200,
+            'flowIdentifier' => '200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt',
+            'flowFilename' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowRelativePath' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowCurrentChunkSize' => 100,
+        ], [], [
+            'file' => $file,
+        ]);
+
+        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
+        $response = $this->createTestResponse($this->handler->handle($request));
+        $response->assertSuccessful();
+        $response->assertJson(['done' => 100]);
+
+        Storage::disk('local')->assertExists('chunks/200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt/100-199');
+        Storage::disk('local')->assertExists($file->hashName('merged'));
+
+        Event::assertDispatched(FileUploaded::class, function ($event) use ($file) {
+            return $event->file = $file->hashName('merged');
+        });
+    }
+
+    public function testUploadLastChunkWithCallback()
+    {
+        $this->createFakeLocalFile('chunks/200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt', '000-099');
+
+        $file = UploadedFile::fake()->create('test.txt', 100);
+        $request = Request::create('', Request::METHOD_POST, [
+            'flowChunkNumber' => 2,
+            'flowTotalChunks' => 2,
+            'flowChunkSize' => 100,
+            'flowTotalSize' => 200,
+            'flowIdentifier' => '200-0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zftxt',
+            'flowFilename' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowRelativePath' => '0jWZTB1ZDfRQU6VTcXy0mJnL9xKMeEz3HoSPU0Zf.txt',
+            'flowCurrentChunkSize' => 100,
+        ], [], [
+            'file' => $file,
+        ]);
+
+        $callback = $this->createClosureMock(
+            $this->once(),
+            'local',
+            $file->hashName('merged')
+        );
+
+        $this->handler->handle($request, $callback);
+
+        Event::assertDispatched(FileUploaded::class, function ($event) use ($file) {
+            return $event->file = $file->hashName('merged');
+        });
+    }
+}


### PR DESCRIPTION
Blocked by #43

https://github.com/flowjs/flow.js#handling-get-or-test-requests

> * If this request returns a `200`, `201` or `202` HTTP code, the chunks is assumed to have been completed.
> * If request returns a permanent error status, upload is stopped.
> * If request returns anything else, the chunk will be uploaded in the standard fashion.

Closes #9