### PR TITLE
Fix file identifier

### DIFF
--- a/src/Driver/BlueimpUploadDriver.php
+++ b/src/Driver/BlueimpUploadDriver.php
@@ -148,7 +148,7 @@ class BlueimpUploadDriver extends UploadDriver
             throw new BadRequestHttpException($e->getMessage(), $e);
         }
 
-        $uuid = $this->identifier->generateUploadedFileIdentifierName($file);
+        $uuid = $this->identifier->generateFileIdentifierName($file, $range->getTotal());
 
         $chunks = $this->storeChunk($config, $range, $file, $uuid);
 

--- a/src/Driver/BlueimpUploadDriver.php
+++ b/src/Driver/BlueimpUploadDriver.php
@@ -148,7 +148,7 @@ class BlueimpUploadDriver extends UploadDriver
             throw new BadRequestHttpException($e->getMessage(), $e);
         }
 
-        $uuid = $this->identifier->generateFileIdentifierName($file, $range->getTotal());
+        $uuid = $this->identifier->generateFileIdentifier($file->getClientOriginalName(), $range->getTotal());
 
         $chunks = $this->storeChunk($config, $range, $file, $uuid);
 
@@ -178,7 +178,6 @@ class BlueimpUploadDriver extends UploadDriver
     public function delete(Request $request, StorageConfig $config): Response
     {
         $filename = $request->post($this->fileParam);
-
         $path = $config->getMergedDirectory() . '/' . $filename;
         Storage::disk($config->getDisk())->delete($path);
 

--- a/src/Driver/BlueimpUploadDriver.php
+++ b/src/Driver/BlueimpUploadDriver.php
@@ -112,7 +112,7 @@ class BlueimpUploadDriver extends UploadDriver
 
         $originalFilename = $request->query($this->fileParam);
         $totalSize = $request->query('totalSize');
-        $uuid = $this->identifier->generateFileIdentifier($originalFilename, $totalSize);
+        $uuid = $this->identifier->generateFileIdentifier($totalSize, $originalFilename);
 
         if (!$this->chunkExists($config, $uuid)) {
             return new JsonResponse([
@@ -154,7 +154,7 @@ class BlueimpUploadDriver extends UploadDriver
             throw new BadRequestHttpException($e->getMessage(), $e);
         }
 
-        $uuid = $this->identifier->generateFileIdentifier($file->getClientOriginalName(), $range->getTotal());
+        $uuid = $this->identifier->generateFileIdentifier($range->getTotal(), $file->getClientOriginalName());
 
         $chunks = $this->storeChunk($config, $range, $file, $uuid);
 

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -14,14 +14,15 @@ abstract class Identifier
     abstract public function generateIdentifier(string $data): string;
 
     /**
-     * @param \Illuminate\Http\UploadedFile $file
+     * @param \Illuminate\Http\UploadedFile $chunk
+     * @param $totalSize
      *
      * @return string
      */
-    public function generateUploadedFileIdentifierName(UploadedFile $file): string
+    public function generateFileIdentifierName(UploadedFile $chunk, $totalSize): string
     {
-        $data = $file->getClientOriginalName();
+        $data = $totalSize . '_' . $chunk->getClientOriginalName();
 
-        return $this->generateIdentifier($data) . '.' . $file->guessExtension();
+        return $this->generateIdentifier($data);
     }
 }

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -12,12 +12,12 @@ abstract class Identifier
     abstract public function generateIdentifier(string $data): string;
 
     /**
-     * @param string $originalFilename
      * @param float $totalSize
+     * @param string $originalFilename
      *
      * @return string
      */
-    public function generateFileIdentifier(string $originalFilename, float $totalSize): string
+    public function generateFileIdentifier(float $totalSize, string $originalFilename): string
     {
         $data = $totalSize . '_' . $originalFilename;
 

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -2,8 +2,6 @@
 
 namespace LaraCrafts\ChunkUploader\Identifier;
 
-use Illuminate\Http\UploadedFile;
-
 abstract class Identifier
 {
     /**
@@ -14,14 +12,14 @@ abstract class Identifier
     abstract public function generateIdentifier(string $data): string;
 
     /**
-     * @param \Illuminate\Http\UploadedFile $chunk
-     * @param $totalSize
+     * @param string $originalFilename
+     * @param float $totalSize
      *
      * @return string
      */
-    public function generateFileIdentifierName(UploadedFile $chunk, $totalSize): string
+    public function generateFileIdentifier(string $originalFilename, float $totalSize): string
     {
-        $data = $totalSize . '_' . $chunk->getClientOriginalName();
+        $data = $totalSize . '_' . $originalFilename;
 
         return $this->generateIdentifier($data);
     }

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -98,7 +98,7 @@ class BlueimpUploadDriverTest extends TestCase
 
         $request = Request::create('', Request::METHOD_GET, [
             'file' => '2494cefe4d234bd331aeb4514fe97d810efba29b.txt',
-            'totalSize' => '200'
+            'totalSize' => '200',
         ]);
 
         $response = $this->createTestResponse($this->handler->handle($request));

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -149,7 +149,7 @@ class BlueimpUploadDriverTest extends TestCase
         $response->assertSuccessful();
         $response->assertJson(['done' => 50]);
 
-        Storage::disk('local')->assertExists('chunks/2494cefe4d234bd331aeb4514fe97d810efba29b.txt/000-099');
+        Storage::disk('local')->assertExists('chunks/5d5115c1064c6e9dead0b7b71506bdfe273fd11c/000-099');
 
         Event::assertNotDispatched(FileUploaded::class, function ($event) use ($file) {
             return $event->file = $file->hashName('merged');
@@ -190,7 +190,7 @@ class BlueimpUploadDriverTest extends TestCase
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);
 
-        Storage::disk('local')->assertExists('chunks/2494cefe4d234bd331aeb4514fe97d810efba29b.txt/100-199');
+        Storage::disk('local')->assertExists('chunks/5d5115c1064c6e9dead0b7b71506bdfe273fd11c/100-199');
         Storage::disk('local')->assertExists($file->hashName('merged'));
 
         Event::assertDispatched(FileUploaded::class, function ($event) use ($file) {

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -94,10 +94,11 @@ class BlueimpUploadDriverTest extends TestCase
 
     public function testResume()
     {
-        $this->createFakeLocalFile('chunks/2494cefe4d234bd331aeb4514fe97d810efba29b.txt', '000-099');
+        $this->createFakeLocalFile('chunks/4f0fce4ab7d03efd246b25d3c9e6546a0d65794d', '000-099');
 
         $request = Request::create('', Request::METHOD_GET, [
             'file' => '2494cefe4d234bd331aeb4514fe97d810efba29b.txt',
+            'totalSize' => '200'
         ]);
 
         $response = $this->createTestResponse($this->handler->handle($request));

--- a/tests/Identifier/SessionIdentifierTest.php
+++ b/tests/Identifier/SessionIdentifierTest.php
@@ -39,14 +39,14 @@ class SessionIdentifierTest extends TestCase
     public function testUploadedFileIdentifierName()
     {
         $file = UploadedFile::fake()->create('test.txt', 100);
-        $identifier = $this->identifier->generateUploadedFileIdentifierName($file);
-        $this->assertEquals('2494cefe4d234bd331aeb4514fe97d810efba29b.txt', $identifier);
+        $identifier = $this->identifier->generateFileIdentifierName($file, 200);
+        $this->assertEquals('5d5115c1064c6e9dead0b7b71506bdfe273fd11c', $identifier);
     }
 
     public function testUploadedFileIdentifierNameWithoutExtension()
     {
         $file = UploadedFile::fake()->create('test', 100);
-        $identifier = $this->identifier->generateUploadedFileIdentifierName($file);
-        $this->assertEquals('3b7b99bf70a98a544319cf3bad9e912e1b89984d.bin', $identifier);
+        $identifier = $this->identifier->generateFileIdentifierName($file, 200);
+        $this->assertEquals('19daf2dc95ccbc0c856a1ce7a13c949f9e81fd2e', $identifier);
     }
 }

--- a/tests/Identifier/SessionIdentifierTest.php
+++ b/tests/Identifier/SessionIdentifierTest.php
@@ -38,15 +38,13 @@ class SessionIdentifierTest extends TestCase
 
     public function testUploadedFileIdentifierName()
     {
-        $file = UploadedFile::fake()->create('test.txt', 100);
-        $identifier = $this->identifier->generateFileIdentifierName($file, 200);
+        $identifier = $this->identifier->generateFileIdentifier('test.txt', 200);
         $this->assertEquals('5d5115c1064c6e9dead0b7b71506bdfe273fd11c', $identifier);
     }
 
     public function testUploadedFileIdentifierNameWithoutExtension()
     {
-        $file = UploadedFile::fake()->create('test', 100);
-        $identifier = $this->identifier->generateFileIdentifierName($file, 200);
+        $identifier = $this->identifier->generateFileIdentifier('test', 200);
         $this->assertEquals('19daf2dc95ccbc0c856a1ce7a13c949f9e81fd2e', $identifier);
     }
 }

--- a/tests/Identifier/SessionIdentifierTest.php
+++ b/tests/Identifier/SessionIdentifierTest.php
@@ -37,13 +37,13 @@ class SessionIdentifierTest extends TestCase
 
     public function testUploadedFileIdentifierName()
     {
-        $identifier = $this->identifier->generateFileIdentifier('test.txt', 200);
+        $identifier = $this->identifier->generateFileIdentifier(200, 'test.txt');
         $this->assertEquals('5d5115c1064c6e9dead0b7b71506bdfe273fd11c', $identifier);
     }
 
     public function testUploadedFileIdentifierNameWithoutExtension()
     {
-        $identifier = $this->identifier->generateFileIdentifier('test', 200);
+        $identifier = $this->identifier->generateFileIdentifier(200, 'test');
         $this->assertEquals('19daf2dc95ccbc0c856a1ce7a13c949f9e81fd2e', $identifier);
     }
 }

--- a/tests/Identifier/SessionIdentifierTest.php
+++ b/tests/Identifier/SessionIdentifierTest.php
@@ -25,25 +25,13 @@ class SessionIdentifierTest extends TestCase
 
     public function testGenerateIdentifier()
     {
-        $identifier = $this->identifier->generateIdentifier('test.txt');
-        $this->assertEquals('2494cefe4d234bd331aeb4514fe97d810efba29b', $identifier);
-    }
-
-    public function testGenerateIdentifierWithoutExtension()
-    {
-        $identifier = $this->identifier->generateIdentifier('test');
-        $this->assertEquals('3b7b99bf70a98a544319cf3bad9e912e1b89984d', $identifier);
+        $identifier = $this->identifier->generateIdentifier('any_string');
+        $this->assertEquals('b41d07049729f460973494395f9bf8fe23834d48', $identifier);
     }
 
     public function testUploadedFileIdentifierName()
     {
-        $identifier = $this->identifier->generateFileIdentifier(200, 'test.txt');
-        $this->assertEquals('5d5115c1064c6e9dead0b7b71506bdfe273fd11c', $identifier);
-    }
-
-    public function testUploadedFileIdentifierNameWithoutExtension()
-    {
-        $identifier = $this->identifier->generateFileIdentifier(200, 'test');
-        $this->assertEquals('19daf2dc95ccbc0c856a1ce7a13c949f9e81fd2e', $identifier);
+        $identifier = $this->identifier->generateFileIdentifier(200, 'any_filename.ext');
+        $this->assertEquals('ec1669bf4dee72e6dd30b94d2d29413601f1b69b', $identifier);
     }
 }

--- a/tests/Identifier/SessionIdentifierTest.php
+++ b/tests/Identifier/SessionIdentifierTest.php
@@ -2,7 +2,6 @@
 
 namespace LaraCrafts\ChunkUploader\Tests\Identifier;
 
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Session;
 use LaraCrafts\ChunkUploader\Identifier\SessionIdentifier;
 use Orchestra\Testbench\TestCase;


### PR DESCRIPTION
In #36 an incorrect modification was added to identity generation.

The extension of a binary chunk can not be guessed except for the first chunk. This means that the first chunk has a different ID than the rest of the chunks.

To better distinguish files `totalFileSize` should be used for ID generation instead of `$chunk->guessExtension()`.