### PR TITLE
Clean up tests

### DIFF
--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -29,12 +29,10 @@ class BlueimpUploadDriverTest extends TestCase
     {
         parent::setUp();
 
+        $this->app->make('config')->set('chunk-uploader.identifier', 'nop');
         $this->app->make('config')->set('chunk-uploader.uploader', 'blueimp');
         $this->app->make('config')->set('chunk-uploader.sweep', false);
         $this->handler = $this->app->make(UploadHandler::class);
-
-        Session::shouldReceive('getId')
-            ->andReturn('frgYt7cPmNGtORpRCo4xvFIrWklzFqc2mnO6EE6b');
 
         Storage::fake('local');
         Event::fake();
@@ -82,7 +80,7 @@ class BlueimpUploadDriverTest extends TestCase
             'download' => 1,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse|\Symfony\Component\HttpFoundation\BinaryFileResponse $response */
+        /** @var \Illuminate\Testing\TestResponse|\Symfony\Component\HttpFoundation\BinaryFileResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertStatus(200);
@@ -94,10 +92,10 @@ class BlueimpUploadDriverTest extends TestCase
 
     public function testResume()
     {
-        $this->createFakeLocalFile('chunks/4f0fce4ab7d03efd246b25d3c9e6546a0d65794d', '000-099');
+        $this->createFakeLocalFile('chunks/200_test.txt', '000-099');
 
         $request = Request::create('', Request::METHOD_GET, [
-            'file' => '2494cefe4d234bd331aeb4514fe97d810efba29b.txt',
+            'file' => 'test.txt',
             'totalSize' => '200',
         ]);
 
@@ -106,7 +104,7 @@ class BlueimpUploadDriverTest extends TestCase
 
         $response->assertJson([
             'file' => [
-                'name' => '2494cefe4d234bd331aeb4514fe97d810efba29b.txt',
+                'name' => 'test.txt',
                 'size' => 100,
             ],
         ]);
@@ -145,12 +143,11 @@ class BlueimpUploadDriverTest extends TestCase
             'HTTP_CONTENT_RANGE' => 'bytes 0-99/200',
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 50]);
 
-        Storage::disk('local')->assertExists('chunks/5d5115c1064c6e9dead0b7b71506bdfe273fd11c/000-099');
+        Storage::disk('local')->assertExists('chunks/200_test.txt/000-099');
 
         Event::assertNotDispatched(FileUploaded::class, function ($event) use ($file) {
             return $event->file = $file->hashName('merged');
@@ -177,7 +174,7 @@ class BlueimpUploadDriverTest extends TestCase
 
     public function testUploadLastChunk()
     {
-        $this->createFakeLocalFile('chunks/2494cefe4d234bd331aeb4514fe97d810efba29b.txt', '000');
+        $this->createFakeLocalFile('chunks/200_test.txt', '000');
 
         $file = UploadedFile::fake()->create('test.txt', 100);
         $request = Request::create('', Request::METHOD_POST, [], [], [
@@ -186,12 +183,11 @@ class BlueimpUploadDriverTest extends TestCase
             'HTTP_CONTENT_RANGE' => 'bytes 100-199/200',
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);
 
-        Storage::disk('local')->assertExists('chunks/5d5115c1064c6e9dead0b7b71506bdfe273fd11c/100-199');
+        Storage::disk('local')->assertExists('chunks/200_test.txt/100-199');
         Storage::disk('local')->assertExists($file->hashName('merged'));
 
         Event::assertDispatched(FileUploaded::class, function ($event) use ($file) {
@@ -201,7 +197,7 @@ class BlueimpUploadDriverTest extends TestCase
 
     public function testUploadLastChunkWithCallback()
     {
-        $this->createFakeLocalFile('chunks/2494cefe4d234bd331aeb4514fe97d810efba29b.txt', '000');
+        $this->createFakeLocalFile('chunks/200_test.txt', '000');
 
         $file = UploadedFile::fake()->create('test.txt', 100);
         $request = Request::create('', Request::METHOD_POST, [], [], [

--- a/tests/Driver/BlueimpUploadDriverTest.php
+++ b/tests/Driver/BlueimpUploadDriverTest.php
@@ -10,7 +10,6 @@ use CodingSocks\ChunkUploader\UploadHandler;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Mockery;
 use PHPUnit\Framework\Constraint\StringContains;

--- a/tests/Driver/DropzoneUploadDriverTest.php
+++ b/tests/Driver/DropzoneUploadDriverTest.php
@@ -72,7 +72,6 @@ class DropzoneUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);
@@ -155,7 +154,6 @@ class DropzoneUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 50]);
@@ -206,7 +204,6 @@ class DropzoneUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);

--- a/tests/Driver/FlowJsUploadDriverTest.php
+++ b/tests/Driver/FlowJsUploadDriverTest.php
@@ -190,7 +190,6 @@ class FlowJsUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 50]);
@@ -245,7 +244,6 @@ class FlowJsUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);

--- a/tests/Driver/MonolithUploadDriverTest.php
+++ b/tests/Driver/MonolithUploadDriverTest.php
@@ -50,7 +50,7 @@ class MonolithUploadDriverTest extends TestCase
             'file' => 'local-test-file',
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse|\Symfony\Component\HttpFoundation\BinaryFileResponse $response */
+        /** @var \Illuminate\Testing\TestResponse|\Symfony\Component\HttpFoundation\BinaryFileResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertStatus(200);
@@ -102,7 +102,6 @@ class MonolithUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
 

--- a/tests/Driver/ResumableJsUploadDriverTest.php
+++ b/tests/Driver/ResumableJsUploadDriverTest.php
@@ -195,7 +195,6 @@ class ResumableJsUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 50]);
@@ -252,7 +251,6 @@ class ResumableJsUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);

--- a/tests/Driver/SimpleUploaderUploadDriverTest.php
+++ b/tests/Driver/SimpleUploaderUploadDriverTest.php
@@ -190,7 +190,6 @@ class SimpleUploaderUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 50]);
@@ -245,7 +244,6 @@ class SimpleUploaderUploadDriverTest extends TestCase
             'file' => $file,
         ]);
 
-        /** @var \Illuminate\Foundation\Testing\TestResponse $response */
         $response = $this->createTestResponse($this->handler->handle($request));
         $response->assertSuccessful();
         $response->assertJson(['done' => 100]);


### PR DESCRIPTION
With NOP identifier there is no need to calculate sha1 identifiers for files in tests or mocking session id.

As well, Laravel started to add return types in their doc blocks which means type comments can be removed.