### PR TITLE
Add auth identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ Service                                   | Driver name
 
 ### Session identifier
 
-This identifier uses the client session, and the original file name to create an identifier for the upload file.
+This identifier uses the client session and the original file name to create an identifier for the upload file.
 
 ### Auth identifier
 
-This identifier uses the id of the authenticated user, and the original file name to create an identifier for the upload file.
+This identifier uses the id of the authenticated user and the original file name to create an identifier for the upload file.
 
 It will throw `UnauthorizedException` when the user is unauthorized. However, it is still recommended to use the `auth` middleware.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ project at the moment is [tus](https://tus.io/).
     - [simple-uploader.js](#simple-uploader-js-driver)
 - [Identifiers](#identifiers)
     - [Session identifier](#session-identifier)
+    - [Auth identifier](#auth-identifier)
     - [NOP identifier](#nop-identifier)
 - [Contribution](#contribution)
 - [License](#license)
@@ -223,11 +224,18 @@ file for a specific client. Without the identifier collisions can happen.
 Service                                   | Driver name
 ------------------------------------------|-------------
 [Session identifier](#session-identifier) | `session`
+[Auth identifier](#auth-identifier)       | `auth`
 [NOP identifier](#nop-identifier)         | `nop`
 
 ### Session identifier
 
-This identifier uses the client session and, the original file name to create an identifier for the upload file.
+This identifier uses the client session, and the original file name to create an identifier for the upload file.
+
+### Auth identifier
+
+This identifier uses the id of the authenticated user, and the original file name to create an identifier for the upload file.
+
+It will throw `UnauthorizedException` when the user is unauthorized. However, it is still recommended to use the `auth` middleware.
 
 ### NOP identifier
 

--- a/config/chunk-uploader.php
+++ b/config/chunk-uploader.php
@@ -28,7 +28,7 @@ return [
     | specify which one you're using throughout your application here. By
     | default, the module is setup for session identity.
     |
-    | Supported: "session"
+    | Supported: "auth", "nop", "session"
     |
      */
 

--- a/src/Identifier/AuthIdentifier.php
+++ b/src/Identifier/AuthIdentifier.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CodingSocks\ChunkUploader\Identifier;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\UnauthorizedException;
+
+class AuthIdentifier extends Identifier
+{
+    public function generateIdentifier(string $data): string
+    {
+        if (!Auth::check()) {
+            throw new UnauthorizedException();
+        }
+        return sha1(Auth::id() . '_' . $data);
+    }
+}

--- a/src/IdentityManager.php
+++ b/src/IdentityManager.php
@@ -2,6 +2,7 @@
 
 namespace CodingSocks\ChunkUploader;
 
+use CodingSocks\ChunkUploader\Identifier\AuthIdentifier;
 use CodingSocks\ChunkUploader\Identifier\NopIdentifier;
 use CodingSocks\ChunkUploader\Identifier\SessionIdentifier;
 use Illuminate\Support\Manager;
@@ -11,6 +12,11 @@ class IdentityManager extends Manager
     public function createSessionDriver()
     {
         return new SessionIdentifier();
+    }
+
+    public function createAuthDriver()
+    {
+        return new AuthIdentifier();
     }
 
     public function createNopDriver()

--- a/tests/Identifier/AuthIdentifierTest.php
+++ b/tests/Identifier/AuthIdentifierTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace CodingSocks\ChunkUploader\Tests\Identifier;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\UnauthorizedException;
+use CodingSocks\ChunkUploader\Identifier\AuthIdentifier;
+use Orchestra\Testbench\TestCase;
+
+class AuthIdentifierTest extends TestCase
+{
+    /**
+     * @var \CodingSocks\ChunkUploader\Identifier\Identifier
+     */
+    private $identifier;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Auth::shouldReceive('id')
+            ->andReturn(100);
+
+        $this->identifier = new AuthIdentifier();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Auth::clearResolvedInstances();
+    }
+
+    public function testGenerateIdentifierThrowsUnauthorizedException()
+    {
+        Auth::shouldReceive('check')
+            ->andReturn(false);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->identifier->generateIdentifier('any_string');
+    }
+
+    public function testGenerateIdentifier()
+    {
+        Auth::shouldReceive('check')
+            ->andReturn(true);
+
+        $identifier = $this->identifier->generateIdentifier('any_string');
+        $this->assertEquals('2b2ea43a7652e1f7925c588b9ae7a31f09be3bf9', $identifier);
+    }
+
+    public function testUploadedFileIdentifierName()
+    {
+        Auth::shouldReceive('check')
+            ->andReturn(true);
+
+        $identifier = $this->identifier->generateFileIdentifier(200, 'any_filename.ext');
+        $this->assertEquals('4317e3d56e27deda5bd84dd35830bff799736257', $identifier);
+    }
+}

--- a/tests/Identifier/AuthIdentifierTest.php
+++ b/tests/Identifier/AuthIdentifierTest.php
@@ -2,9 +2,9 @@
 
 namespace CodingSocks\ChunkUploader\Tests\Identifier;
 
+use CodingSocks\ChunkUploader\Identifier\AuthIdentifier;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\UnauthorizedException;
-use CodingSocks\ChunkUploader\Identifier\AuthIdentifier;
 use Orchestra\Testbench\TestCase;
 
 class AuthIdentifierTest extends TestCase


### PR DESCRIPTION
This PR adds an auth identifier which concatenates the given data and the user id. It throws `UnauthorizedException` if auth check returns false.

Closes #54 